### PR TITLE
Add .gitignore and Makefile with builds/ output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 # Local dev files
 local_ignored/
 
+# Go build output
+builds/
+
 # Python
 __pycache__/
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+BUILD_DIR := builds
+
+.PHONY: build build-api build-indexer clean
+
+build: build-api build-indexer
+
+build-api:
+	go build -o $(BUILD_DIR)/api ./cmd/api
+
+build-indexer:
+	go build -o $(BUILD_DIR)/indexer ./cmd/indexer
+
+clean:
+	rm -rf $(BUILD_DIR)


### PR DESCRIPTION
## Summary
- Add `.gitignore` covering build output, local dev files, Python cache, and Foundry artifacts
- Add `Makefile` that builds API and indexer binaries into `builds/` directory

## Test plan
- [ ] `make build` outputs binaries to `builds/`
- [ ] `git status` does not show `builds/` after building

🤖 Generated with [Claude Code](https://claude.com/claude-code)